### PR TITLE
chore: add missing react-markdown dependency

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -24,6 +24,7 @@
     "ogl": "^1.0.11",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
+    "react-markdown": "^10.1.0",
     "react-router-dom": "^7.14.2",
     "shadcn": "^4.3.0",
     "sonner": "^2.0.7",


### PR DESCRIPTION
Adds the missing `react-markdown` dependency in `packages/web/package.json` that was left out after the previous merge.